### PR TITLE
vetKD initial draft

### DIFF
--- a/spec/ic.did
+++ b/spec/ic.did
@@ -25,6 +25,7 @@ type http_response = record {
 };
 
 type ecdsa_curve = variant { secp256k1; };
+type vetkd_curve = variant { bls12_381; };
 
 type satoshi = nat64;
 
@@ -132,6 +133,19 @@ service ic : {
     derivation_path : vec blob;
     key_id : record { curve: ecdsa_curve; name: text };
   }) -> (record { signature : blob });
+
+  // Threshold key derivation
+  vetkd_public_key : (record {
+    canister_id : opt canister_id;
+    derivation_path : vec blob;
+    key_id : record { curve : vetkd_curve; name : text };
+  }) -> (record { public_key : blob; });
+  vetkd_encrypted_key : (record {
+    derivation_path : vec blob;
+    derivation_id : blob;
+    key_id : record { curve : vetkd_curve; name : text };
+    transport_public_key : blob;
+  }) -> (record { encrypted_key : blob; });
 
   // bitcoin interface
   bitcoin_get_balance: (get_balance_request) -> (satoshi);

--- a/spec/ic.did
+++ b/spec/ic.did
@@ -141,10 +141,10 @@ service ic : {
     key_id : record { curve : vetkd_curve; name : text };
   }) -> (record { public_key : blob; });
   vetkd_encrypted_key : (record {
-    derivation_path : vec blob;
+    public_key_derivation_path : vec blob;
     derivation_id : blob;
     key_id : record { curve : vetkd_curve; name : text };
-    transport_public_key : blob;
+    encryption_public_key : blob;
   }) -> (record { encrypted_key : blob; });
 
   // bitcoin interface

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1683,11 +1683,11 @@ NOTE: The ECDSA API is considered EXPERIMENTAL. Canister developers must be awar
 This method returns a https://www.secg.org/sec1-v2.pdf[SEC1] encoded ECDSA public key for the given canister using the given derivation path. If the `canister_id` is unspecified, it will default to the canister id of the caller.
 The `derivation_path` is a vector of variable length byte strings.
 The `key_id` is a struct specifying both a curve and a name.
-The availability of a particular `key_id` depends on implementation.
+The availability of a particular `key_id` depends on the implementation.
 
 For curve `secp256k1`, the public key is derived using a generalization of BIP32 (see https://ia.cr/2021/1330[ia.cr/2021/1330, Appendix D]). To derive (non-hardened) https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki[BIP-0032]-compatible public keys, each byte string (`blob`) in the `derivation_path` must be a 4-byte big-endian encoding of an unsigned integer less than 2^31^.
 
-The return result is an extended public key consisting of an ECDSA `public_key`, encoded in https://www.secg.org/sec2-v2.pdf[SEC1] compressed form, and a `chain_code`, which can be used to deterministically derive child keys of the `public_key`.
+The return value is an extended public key consisting of an ECDSA `public_key`, encoded in https://www.secg.org/sec2-v2.pdf[SEC1] compressed form, and a `chain_code`, which can be used to deterministically derive child keys of the `public_key`.
 
 This call requires that the ECDSA feature is enabled, and the `canister_id` meets the requirement of a canister id.
 Otherwise it will be rejected.
@@ -1704,6 +1704,67 @@ The signatures are encoded as the concatenation of the https://www.secg.org/sec2
 
 This call requires that the ECDSA feature is enabled, the caller is a canister, and `message_hash` is 32 bytes long.
 Otherwise it will be rejected.
+
+[#ic-vetkd_public_key]
+=== IC method `vetkd_public_key`
+
+NOTE: The vetKD API is considered EXPERIMENTAL. Canister developers must be aware that the API may evolve in a non-backward-compatible way.
+
+This method returns a (derived) vetKD public key for the given canister using the given derivation path.
+
+If the `canister_id` is unspecified, it will default to the canister id of the caller.
+The `derivation_path` is a vector of variable length byte strings, containing at most 255 byte strings.
+The `key_id` is a struct specifying both a curve and a name.
+The availability of a particular `key_id` depends on the implementation.
+
+For curve `bls12_381`, the following holds:
+
+* The returned `public_key` is a G~2~ element in compressed form encoded according to the https://docs.rs/bls12_381/0.8.0/bls12_381/notes/serialization/index.html[Zcash] rules.
+TODO: Would it make any sense for the curve `bls12_381` to reuse the encoding we also expect of BLS public keys for certificates, namely DER encoding, following https://tools.ietf.org/html/rfc5480[RFC5480] using OID 1.3.6.1.4.1.44668.5.3.1.2.1 for the algorithm and 1.3.6.1.4.1.44668.5.3.2.1 for the curve.
+
+* The public key is an encryption key in a Boneh-Franklin identity-based encryption (BF-IBE) scheme for identity `derivation_path`, where the corresponding decryption key can be obtained by calling `vetkd_encrypted_key` with the same `derivation_path` and `key_id` as used here. See http://todo.com[TODO] for more details on how to perform asymmetric (identity-based) encryption.
+
+This call requires that the vetKD feature is enabled, and the `canister_id` meets the requirement of a canister id.
+Otherwise it will be rejected.
+
+[#ic-vetkd_encrypted_key]
+=== IC method `vetkd_encrypted_key`
+
+NOTE: The vetKD API is considered EXPERIMENTAL. Canister developers must be aware that the API may evolve in a non-backward-compatible way.
+
+This method returns a vetKD key, encrypted under a user-provided transport public_key, using the given derivation information comprising `derivation_path` and `derivation_id`.
+TODO: explain significance of these two (e.g., why is there a `derivation_id` in addition to the `derivation_path` also used in `vetkd_public_key`).
+The `derivation_path` is a vector of variable length byte strings, containing at most 255 byte strings.
+The `key_id` is a struct specifying both a curve and a name.
+The availability of a particular `key_id` depends on the implementation.
+
+For curve `bls12_381`, the following holds:
+
+* The `transport_public_key` is a G~1~ element in compressed form in https://docs.rs/bls12_381/0.8.0/bls12_381/notes/serialization/index.html[Zcash] encoding. Transport public keys can be obtained by calculating g~1~^tsk^, where the transport secret key _tsk_ is chosen uniformly at random from Z~p~, and g~1~ is a generator of G~1~.
+
+* The returned `encrypted_key` is the blob `E~1~ · E~2~ · E~3~`, where E~1~ and E~3~ are G~1~ elements and E~2~ is a G~2~ element, all in compressed form in https://docs.rs/bls12_381/0.8.0/bls12_381/notes/serialization/index.html[Zcash] encoding, and `·` denotes blob concatenation.
++
+Before usage, the key must be verified by ensuring _e(E~1~, g~2~) = e(g~1~, E~2~)_ and ... TODO: finish.
+
+* The decrypted vetKD key _k_ is obtained by calculating E~3~ · E~1~^-tsk^, where the tsk ∈ Z~p~ is the transport secret key that was used to create the `transport_public_key`.
++
+Before usage, the key must be verified by ensuring _e(k, g~2~) = e(H(dpk || `derivation_id`), dpk)_, where `e: G~1~ x G~2~ -> G~T~` is the pairing, _H_ hashes into G~1~ (TODO: specify!), and _dpk_ is obtained by calling IC method `vetkd_public_key` with the same `derivation_path` and `key_id`, and with the canister id of the caller.
+
+* The (decrypted) vetKD key can act as decryption key in a Boneh-Franklin identity-based encryption (BF-IBE) scheme for identity `derivation_path`, where the corresponding encryption key can be obtained by calling `vetkd_public_key` with the same `derivation_path` and `key_id` as used here. See http://todo.com[TODO] for more details on how to perform asymmetric (identity-based) encryption.
+TODO: is the `derivation_id` relevant for the BF-IBE identity?
+
+* If the `derivation_path` is an empty vector, the decrypted vetKD key is a standard https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature[BLS signature] conforming to the https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature#name-message-augmentation[message augmentation scheme], where the `derivation_id` acts as the message that is signed.
+TODO: verify this with Andrea!
+
+The (decrypted) vetKD key can be used to derive a key for a symmetric encryption scheme (e.g., AES). See http://todo.com[TODO] for more details.
+
+This call requires that the vetKD feature is enabled and the caller is a canister.
+Otherwise it will be rejected.
+
+TODOs:
+* refer to section describing how to BF-IBE encrypt and decrypt.
+* specify further constraints on input data (e.g., max size of `derivation_id`, etc.), if any
+* https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki[BIP-0032]-compatibility is not a topic here, so we don't need to talk about that, or our BIP32 generalization, right?
 
 [#ic-http_request]
 === IC method `http_request`
@@ -1952,7 +2013,7 @@ is the https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04#section-4[BL
 ....
 extract_der : Blob -> Blob
 ....
-implements DER decoding of the public key, following https://tools.ietf.org/html/rfc5480[RFC4580] using OID 1.3.6.1.4.1.44668.5.3.1.2.1 for the algorithm and 1.3.6.1.4.1.44668.5.3.2.1 for the curve.
+implements DER decoding of the public key, following https://tools.ietf.org/html/rfc5480[RFC5480] using OID 1.3.6.1.4.1.44668.5.3.1.2.1 for the algorithm and 1.3.6.1.4.1.44668.5.3.2.1 for the curve.
 
 All state trees include the time at path `/time` (see <<state-tree-time>>). Users that get a certificate with a state tree can look up the timestamp to guard against working on obsolete data.
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1717,61 +1717,92 @@ The `derivation_path` is a vector of variable length byte strings, containing at
 The `key_id` is a struct specifying both a curve and a name.
 The availability of a particular `key_id` depends on the implementation.
 
-For curve `bls12_381`, the following holds:
-
-* The returned `public_key` is a G~2~ element in compressed form in https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-bls12-381[BLS12-381 encoding from the BLS Signatures Draft RFC].
-TODO: Would it make any sense for the curve `bls12_381` to reuse the encoding we also expect of BLS public keys for certificates, namely DER encoding, following https://tools.ietf.org/html/rfc5480[RFC5480] using OID 1.3.6.1.4.1.44668.5.3.1.2.1 for the algorithm and 1.3.6.1.4.1.44668.5.3.2.1 for the curve.
-
-* The public key is an encryption key in a Boneh-Franklin identity-based encryption (BF-IBE) scheme for identity `derivation_path`, where the corresponding decryption key can be obtained by calling `vetkd_encrypted_key` with the same `derivation_path` and `key_id` as used here. See http://todo.com[TODO] for more details on how to perform asymmetric (identity-based) encryption.
+For curve `bls12_381`, the returned `public_key` is a G~2~ element in compressed form in https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-bls12-381[BLS Signatures Draft RFC] encoding.
 
 This call requires that the vetKD feature is enabled, and the `canister_id` meets the requirement of a canister id.
 Otherwise it will be rejected.
+
+*TODOs*:
+
+* Add comment in MR asking if the `public_key` should be DER encoded, if maybe even the encoding we also expect of BLS public keys for certificates, namely DER encoding, following https://tools.ietf.org/html/rfc5480[RFC5480] using OID 1.3.6.1.4.1.44668.5.3.1.2.1 for the algorithm and 1.3.6.1.4.1.44668.5.3.2.1 for the curve should be used.
 
 [#ic-vetkd_encrypted_key]
 === IC method `vetkd_encrypted_key`
 
 NOTE: The vetKD API is considered EXPERIMENTAL. Canister developers must be aware that the API may evolve in a non-backward-compatible way.
 
-This method returns a vetKD key, encrypted under a user-provided transport public_key, using the given derivation information comprising `derivation_path` and `derivation_id`.
-TODO: explain significance of these two (e.g., why is there a `derivation_id` in addition to the `derivation_path` also used in `vetkd_public_key`).
-The `derivation_path` is a vector of variable length byte strings, containing at most 255 byte strings.
+This method returns a vetKD key, encrypted under a user-provided transport public_key, for the calling canister using the given derivation information consisting of `derivation_path` and `derivation_id`.
+
+The `derivation_path` is a vector of variable length byte strings, containing at most 255 byte strings, and (together with the calling canister's ID) acts as domain separator to derive different public (verification) keys with the IC method `vetkd_public_key`.
+The `derivation_id` is used to derive a specific encrypted key.
 The `key_id` is a struct specifying both a curve and a name.
 The availability of a particular `key_id` depends on the implementation.
 
 For curve `bls12_381`, the following holds:
 
-* The `transport_public_key` is a G~1~ element in compressed form in https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-bls12-381[BLS12-381 encoding from the BLS Signatures Draft RFC]. Transport public keys are created by calculating g~1~^tsk^, where the transport secret key _tsk_ is chosen uniformly at random from Z~p~.
+* The `transport_public_key` is a G~1~ element in compressed form in https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-bls12-381[BLS Signatures Draft RFC] encoding. Transport public keys are created by calculating g~1~^tsk^, where the transport secret key _tsk_ is chosen uniformly at random from Z~p~.
 
-* The returned `encrypted_key` is the blob `E~1~ · E~2~ · E~3~`, where E~1~ and E~3~ are G~1~ elements and E~2~ is a G~2~ element, all in compressed form in https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-bls12-381[BLS12-381 encoding from the BLS Signatures Draft RFC], and `·` denotes blob concatenation.
+* The returned `encrypted_key` is the blob `E~1~ · E~2~ · E~3~`, where E~1~ and E~3~ are G~1~ elements, and E~2~ is a G~2~ element, all in compressed form in https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-bls12-381[BLS Signatures Draft RFC] encoding.
 +
-Before usage, the key must be verified by ensuring _e(E~1~, g~2~) = e(g~1~, E~2~)_ and _e(E~3~, g~2~) = e(tpk, E~2~) · e(H(dpk || `derivation_id`), dpk)_, where `||` denotes concatenation, and _dpk_ is obtained by calling IC method `vetkd_public_key` with the same `derivation_path` and `key_id`, and with the canister id of the caller.
+Before usage, the key should be verified by ensuring _e(E~1~, g~2~) = e(g~1~, E~2~)_, and _e(E~3~, g~2~) = e(tpk, E~2~) * e(H(dpk · `derivation_id`), dpk)_, where the derived public key _dpk_ is obtained by calling IC method `vetkd_public_key` with the same `derivation_path` and `key_id`, and the canister id of the caller.
 
 * The decrypted vetKD key _k_ is obtained by calculating E~3~ · E~1~^-tsk^, where the tsk ∈ Z~p~ is the transport secret key that was used to create the `transport_public_key`.
 +
-Before usage, the key must be verified by ensuring _e(k, g~2~) = e(H(dpk || `derivation_id`), dpk)_, where `||` denotes concatenation, and _dpk_ is obtained by calling IC method `vetkd_public_key` with the same `derivation_path` and `key_id`, and with the canister id of the caller.
-
-* The (decrypted) vetKD key can act as decryption key in a Boneh-Franklin identity-based encryption (BF-IBE) scheme for identity `derivation_path`, where the corresponding encryption key can be obtained by calling `vetkd_public_key` with the same `derivation_path` and `key_id` as used here. See http://todo.com[TODO] for more details on how to perform asymmetric (identity-based) encryption.
-TODO: is the `derivation_id` relevant for the BF-IBE identity?
-
-* If the `derivation_path` is an empty vector, the decrypted vetKD key is a standard https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature[BLS signature] conforming to the https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature#name-message-augmentation[message augmentation scheme], where the `derivation_id` acts as the message that is signed.
-TODO: verify this with Andrea!
+Before usage, the key should be verified by ensuring _e(k, g~2~) = e(H(dpk · `derivation_id`), dpk)_, where _dpk_ is obtained by calling IC method `vetkd_public_key` with the same `derivation_path` and `key_id`, and the canister id of the caller.
 
 where
 
 * g~1~, g~2~ are generators of G~1~, G~2~,
-* `e: G~1~ x G~2~ -> G~T~` is the bilinear pairing,
-* H hashes into G~1~ (TODO: specify details)
-
-
-The (decrypted) vetKD key can be used to derive a key for a symmetric encryption scheme (e.g., AES). See http://todo.com[TODO] for more details.
+* e: `G~1~ x G~2~ -> G~T~` is the pairing (see https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-bls12-381[BLS Signatures Draft RFC, Appendix A]),
+* H hashes into G~1~ according to the https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature#name-message-augmentation-2[BLS12-381 message augmentation scheme ciphersuite in the BLS Signatures Draft RFC] (see also https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve#name-suites-for-bls12-381[Hashing to Elliptic Curves Draft RFC]),
+* `·` denotes concatenation
 
 This call requires that the vetKD feature is enabled and the caller is a canister.
 Otherwise it will be rejected.
 
-TODOs:
-* refer to section describing how to BF-IBE encrypt and decrypt.
-* specify further constraints on input data (e.g., max size of `derivation_id`, etc.), if any
-* https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki[BIP-0032]-compatibility is not a topic here, so we don't need to talk about that, or our BIP32 generalization, right?
+*TODOs*:
+
+* Specify further constraints on input data, if any (e.g., max size of `derivation_id`, etc.)
+
+[#ic-vetkd-key-usage]
+=== Usage of vetKD keys
+
+NOTE: This section shall eventually live *outside* of the IC interface spec, e.g., in the https://internetcomputer.org/docs/current/home[Developer Docs] under https://internetcomputer.org/docs/current/developer-docs/integrations/[Guides -> Advanced Features] -> Threshold Key Derivation.
+
+A decrypted vetKD key (obtained in encrypted form via IC method `vetkd_encrypted_key`), potentially together with it's public part (obtained via IC method `vetkd_public_key`) can be used for a variety of use cases, some of which are described in the following.
+
+==== Symmetric key derivation (PRF)
+
+A decrypted vetKD key can be used to derive a symmetric key to be used for symmetric-key encryption, i.e., for both encryption and decryption of a message.
+For curve `bls12_381`, this is possible because the decrypted vetKD key is actually a (threshold) BLS signature, and BLS signatures are unique. This uniqueness makes them amenable to a pseudo-random function (PRF), where the pseudo-random output is easily obtained by applying a hash function modeled as a random oracle to the decrypted vetKD key.
+
+*TODOs*:
+
+* Give more details on how to derive keys (H?, HKDF?, etc.)
+* Give examples of how canisters can use these keys, e.g., for end-to-end encrypted storage or end-to-end encrypted messaging.
+
+==== Asymmetric (identity-based) encryption
+
+The decrypted vetKD key can act as decryption key in a Boneh-Franklin identity-based encryption (BF-IBE) scheme for identity `derivation_path`, where the corresponding encryption key can be obtained by calling `vetkd_public_key` with the same `derivation_path` and `key_id`.
+
+See http://todo.com[TODO] for more details on how to perform asymmetric (identity-based) encryption.
+
+*TODOs*:
+
+* Figure out if the `derivation_id` is relevant for the BF-IBE identity? If yes, explain how.
+* Give more details on how exactly asymmetric (identity-based) encryption is done: see `ibe_encrypt` and `ibe_decrypt` in the design document.
+* Give examples of how canisters can use these keys, e.g., for end-to-end encrypted messaging.
+
+==== BLS signatures (VRF?)
+
+For curve `bls12_381`, the decrypted vetKD key is a standard BLS signature conforming to the https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature#name-message-augmentation[message augmentation scheme], where the `derivation_id` acts as the message that is signed.
+
+The public key to verify the signature can be obtained by calling IC method `vetkd_public_key` with the same `derivation_path` and `key_id`.
+
+*TODOs*:
+
+* Verify if the above is correct.
+* Give more details?
 
 [#ic-http_request]
 === IC method `http_request`

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1719,7 +1719,7 @@ The availability of a particular `key_id` depends on the implementation.
 
 For curve `bls12_381`, the following holds:
 
-* The returned `public_key` is a G~2~ element in compressed form encoded according to the https://docs.rs/bls12_381/0.8.0/bls12_381/notes/serialization/index.html[Zcash] rules.
+* The returned `public_key` is a G~2~ element in compressed form in https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-bls12-381[BLS12-381 encoding from the BLS Signatures Draft RFC].
 TODO: Would it make any sense for the curve `bls12_381` to reuse the encoding we also expect of BLS public keys for certificates, namely DER encoding, following https://tools.ietf.org/html/rfc5480[RFC5480] using OID 1.3.6.1.4.1.44668.5.3.1.2.1 for the algorithm and 1.3.6.1.4.1.44668.5.3.2.1 for the curve.
 
 * The public key is an encryption key in a Boneh-Franklin identity-based encryption (BF-IBE) scheme for identity `derivation_path`, where the corresponding decryption key can be obtained by calling `vetkd_encrypted_key` with the same `derivation_path` and `key_id` as used here. See http://todo.com[TODO] for more details on how to perform asymmetric (identity-based) encryption.
@@ -1740,21 +1740,28 @@ The availability of a particular `key_id` depends on the implementation.
 
 For curve `bls12_381`, the following holds:
 
-* The `transport_public_key` is a G~1~ element in compressed form in https://docs.rs/bls12_381/0.8.0/bls12_381/notes/serialization/index.html[Zcash] encoding. Transport public keys can be obtained by calculating g~1~^tsk^, where the transport secret key _tsk_ is chosen uniformly at random from Z~p~, and g~1~ is a generator of G~1~.
+* The `transport_public_key` is a G~1~ element in compressed form in https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-bls12-381[BLS12-381 encoding from the BLS Signatures Draft RFC]. Transport public keys are created by calculating g~1~^tsk^, where the transport secret key _tsk_ is chosen uniformly at random from Z~p~.
 
-* The returned `encrypted_key` is the blob `E~1~ · E~2~ · E~3~`, where E~1~ and E~3~ are G~1~ elements and E~2~ is a G~2~ element, all in compressed form in https://docs.rs/bls12_381/0.8.0/bls12_381/notes/serialization/index.html[Zcash] encoding, and `·` denotes blob concatenation.
+* The returned `encrypted_key` is the blob `E~1~ · E~2~ · E~3~`, where E~1~ and E~3~ are G~1~ elements and E~2~ is a G~2~ element, all in compressed form in https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-bls12-381[BLS12-381 encoding from the BLS Signatures Draft RFC], and `·` denotes blob concatenation.
 +
-Before usage, the key must be verified by ensuring _e(E~1~, g~2~) = e(g~1~, E~2~)_ and ... TODO: finish.
+Before usage, the key must be verified by ensuring _e(E~1~, g~2~) = e(g~1~, E~2~)_ and _e(E~3~, g~2~) = e(tpk, E~2~) · e(H(dpk || `derivation_id`), dpk)_, where `||` denotes concatenation, and _dpk_ is obtained by calling IC method `vetkd_public_key` with the same `derivation_path` and `key_id`, and with the canister id of the caller.
 
 * The decrypted vetKD key _k_ is obtained by calculating E~3~ · E~1~^-tsk^, where the tsk ∈ Z~p~ is the transport secret key that was used to create the `transport_public_key`.
 +
-Before usage, the key must be verified by ensuring _e(k, g~2~) = e(H(dpk || `derivation_id`), dpk)_, where `e: G~1~ x G~2~ -> G~T~` is the pairing, _H_ hashes into G~1~ (TODO: specify!), and _dpk_ is obtained by calling IC method `vetkd_public_key` with the same `derivation_path` and `key_id`, and with the canister id of the caller.
+Before usage, the key must be verified by ensuring _e(k, g~2~) = e(H(dpk || `derivation_id`), dpk)_, where `||` denotes concatenation, and _dpk_ is obtained by calling IC method `vetkd_public_key` with the same `derivation_path` and `key_id`, and with the canister id of the caller.
 
 * The (decrypted) vetKD key can act as decryption key in a Boneh-Franklin identity-based encryption (BF-IBE) scheme for identity `derivation_path`, where the corresponding encryption key can be obtained by calling `vetkd_public_key` with the same `derivation_path` and `key_id` as used here. See http://todo.com[TODO] for more details on how to perform asymmetric (identity-based) encryption.
 TODO: is the `derivation_id` relevant for the BF-IBE identity?
 
 * If the `derivation_path` is an empty vector, the decrypted vetKD key is a standard https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature[BLS signature] conforming to the https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature#name-message-augmentation[message augmentation scheme], where the `derivation_id` acts as the message that is signed.
 TODO: verify this with Andrea!
+
+where
+
+* g~1~, g~2~ are generators of G~1~, G~2~,
+* `e: G~1~ x G~2~ -> G~T~` is the bilinear pairing,
+* H hashes into G~1~ (TODO: specify details)
+
 
 The (decrypted) vetKD key can be used to derive a key for a symmetric encryption scheme (e.g., AES). See http://todo.com[TODO] for more details.
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1742,7 +1742,7 @@ For curve `bls12_381`, the following holds:
 +
 The encrypted key can be verified by ensuring _e(E~1~, g~2~) == e(g~1~, E~2~)_, and _e(E~3~, g~2~) == e(epk, E~2~) * e(H(dpk · `derivation_id`), dpk)_, where the derived public key _dpk_ is obtained by calling IC method `vetkd_public_key` with the same `derivation_path` and `key_id`, and the canister id of the caller.
 
-* The decrypted vetKD key _k_ is obtained by calculating E~3~ * E~1~^-esk^, where the tsk ∈ Z~p~ is the encryption secret key that was used to generate the `encryption_public_key`.
+* The decrypted vetKD key _k_ is obtained by calculating E~3~ * E~1~^-esk^, where esk ∈ Z~p~ is the encryption secret key that was used to generate the `encryption_public_key`.
 +
 Before usage, the key must be verified by ensuring _e(k, g~2~) == e(H(dpk · `derivation_id`), dpk)_, where _dpk_ is obtained by calling IC method `vetkd_public_key` with the same `derivation_path` and `key_id`, and the canister id of the caller.
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1744,7 +1744,8 @@ The encrypted key can be verified by ensuring _e(E~1~, g~2~) == e(g~1~, E~2~)_, 
 
 * The decrypted vetKD key _k_ is obtained by calculating E~3~ * E~1~^-esk^, where esk ∈ Z~p~ is the encryption secret key that was used to generate the `encryption_public_key`.
 +
-Before usage, the key must be verified by ensuring _e(k, g~2~) == e(H(dpk · `derivation_id`), dpk)_, where _dpk_ is obtained by calling IC method `vetkd_public_key` with the same `derivation_path` and `key_id`, and the canister id of the caller.
+The key can be verified by ensuring _e(k, g~2~) == e(H(dpk · `derivation_id`), dpk)_, where _dpk_ is obtained by calling IC method `vetkd_public_key` with the same `derivation_path` and `key_id`, and the canister id of the caller.
+Such verification protects against untrusted canisters returning invalid keys.
 
 where
 

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1727,28 +1727,29 @@ Otherwise it will be rejected.
 
 NOTE: The vetKD API is considered EXPERIMENTAL. Canister developers must be aware that the API may evolve in a non-backward-compatible way.
 
-This method returns a vetKD key, encrypted under a user-provided transport public_key, for the calling canister using the given derivation information consisting of `derivation_path` and `derivation_id`.
+This method returns a vetKD key, encrypted under a user-provided encryption public_key, for the calling canister using the given derivation information consisting of `public_key_derivation_path` and `derivation_id`.
 
-The `derivation_path` is a vector of variable length byte strings, containing at most 255 byte strings, and (together with the calling canister's ID) acts as domain separator to derive different public (verification) keys with the IC method `vetkd_public_key`.
-The `derivation_id` is used to derive a specific encrypted key.
+The `public_key_derivation_path` is a vector of variable length byte strings, containing at most 255 byte strings, and (together with the calling canister's ID) acts as domain separator to derive different public (verification) keys with the IC method `vetkd_public_key`.
+The `derivation_id` is used to derive different encrypted keys.
 The `key_id` is a struct specifying both a curve and a name.
 The availability of a particular `key_id` depends on the implementation.
 
 For curve `bls12_381`, the following holds:
 
-* The `transport_public_key` is a G~1~ element in compressed form in https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-bls12-381[BLS Signatures Draft RFC] encoding. Transport public keys are created by calculating g~1~^tsk^, where the transport secret key _tsk_ is chosen uniformly at random from Z~p~.
+* The `encryption_public_key` is a G~1~ element in compressed form in https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-bls12-381[BLS Signatures Draft RFC] encoding. Encryption public keys are created by calculating _epk = g~1~^esk^_, where the encryption secret key _esk_ is chosen uniformly at random from Z~p~.
 
 * The returned `encrypted_key` is the blob `E~1~ · E~2~ · E~3~`, where E~1~ and E~3~ are G~1~ elements, and E~2~ is a G~2~ element, all in compressed form in https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-bls12-381[BLS Signatures Draft RFC] encoding.
 +
-Before usage, the key should be verified by ensuring _e(E~1~, g~2~) = e(g~1~, E~2~)_, and _e(E~3~, g~2~) = e(tpk, E~2~) * e(H(dpk · `derivation_id`), dpk)_, where the derived public key _dpk_ is obtained by calling IC method `vetkd_public_key` with the same `derivation_path` and `key_id`, and the canister id of the caller.
+The encrypted key can be verified by ensuring _e(E~1~, g~2~) == e(g~1~, E~2~)_, and _e(E~3~, g~2~) == e(epk, E~2~) * e(H(dpk · `derivation_id`), dpk)_, where the derived public key _dpk_ is obtained by calling IC method `vetkd_public_key` with the same `derivation_path` and `key_id`, and the canister id of the caller.
 
-* The decrypted vetKD key _k_ is obtained by calculating E~3~ · E~1~^-tsk^, where the tsk ∈ Z~p~ is the transport secret key that was used to create the `transport_public_key`.
+* The decrypted vetKD key _k_ is obtained by calculating E~3~ * E~1~^-esk^, where the tsk ∈ Z~p~ is the encryption secret key that was used to generate the `encryption_public_key`.
 +
-Before usage, the key should be verified by ensuring _e(k, g~2~) = e(H(dpk · `derivation_id`), dpk)_, where _dpk_ is obtained by calling IC method `vetkd_public_key` with the same `derivation_path` and `key_id`, and the canister id of the caller.
+Before usage, the key must be verified by ensuring _e(k, g~2~) == e(H(dpk · `derivation_id`), dpk)_, where _dpk_ is obtained by calling IC method `vetkd_public_key` with the same `derivation_path` and `key_id`, and the canister id of the caller.
 
 where
 
-* g~1~, g~2~ are generators of G~1~, G~2~,
+* g~1~, g~2~ are generators of G~1~, G~2~, which are groups of prime order _p_,
+* * denotes the group operation in G~1~, G~2~, and G~T~,
 * e: `G~1~ x G~2~ -> G~T~` is the pairing (see https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-bls12-381[BLS Signatures Draft RFC, Appendix A]),
 * H hashes into G~1~ according to the https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature#name-message-augmentation-2[BLS12-381 message augmentation scheme ciphersuite in the BLS Signatures Draft RFC] (see also https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve#name-suites-for-bls12-381[Hashing to Elliptic Curves Draft RFC]),
 * `·` denotes concatenation

--- a/spec/index.adoc
+++ b/spec/index.adoc
@@ -1722,10 +1722,6 @@ For curve `bls12_381`, the returned `public_key` is a G~2~ element in compressed
 This call requires that the vetKD feature is enabled, and the `canister_id` meets the requirement of a canister id.
 Otherwise it will be rejected.
 
-*TODOs*:
-
-* Add comment in MR asking if the `public_key` should be DER encoded, if maybe even the encoding we also expect of BLS public keys for certificates, namely DER encoding, following https://tools.ietf.org/html/rfc5480[RFC5480] using OID 1.3.6.1.4.1.44668.5.3.1.2.1 for the algorithm and 1.3.6.1.4.1.44668.5.3.2.1 for the curve should be used.
-
 [#ic-vetkd_encrypted_key]
 === IC method `vetkd_encrypted_key`
 
@@ -1760,10 +1756,6 @@ where
 This call requires that the vetKD feature is enabled and the caller is a canister.
 Otherwise it will be rejected.
 
-*TODOs*:
-
-* Specify further constraints on input data, if any (e.g., max size of `derivation_id`, etc.)
-
 [#ic-vetkd-key-usage]
 === Usage of vetKD keys
 
@@ -1784,8 +1776,6 @@ For curve `bls12_381`, this is possible because the decrypted vetKD key is actua
 ==== Asymmetric (identity-based) encryption
 
 The decrypted vetKD key can act as decryption key in a Boneh-Franklin identity-based encryption (BF-IBE) scheme for identity `derivation_path`, where the corresponding encryption key can be obtained by calling `vetkd_public_key` with the same `derivation_path` and `key_id`.
-
-See http://todo.com[TODO] for more details on how to perform asymmetric (identity-based) encryption.
 
 *TODOs*:
 


### PR DESCRIPTION
Draft extension to specify the vetKD functionality.

#### TODOs
* Determine if we should specify further constraints on input data (e.g., max size of `derivation_id`, etc.)
* Should the `public_key`be DER encoded? If so, should we even use the encoding we also expect of BLS public keys for certificates, namely DER encoding, following https://tools.ietf.org/html/rfc5480[RFC5480] using OID 1.3.6.1.4.1.44668.5.3.1.2.1 for the algorithm and 1.3.6.1.4.1.44668.5.3.2.1 for the curve should be used.